### PR TITLE
Adding Testing Frontend Development section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,13 @@ npm run serve
 ```
 **Note: currently the function `get_country` just returns  country code for `Pakistan` for testing you can change it to your country code.**
 
+### Testing Frontend Development
+
+Following steps to create frontend development:
+
+- Using the Node.js version is v10.19.0 or newer.
+- Using the `npm ci` to install dependencies without overwriting `package-lock.json` file.
+- Using the `npm run serve` command to build Vue.js and have the static page serving on the devleopment server.
 
 **Thanks**
 ## License  


### PR DESCRIPTION
# Changed log

- Adding the section to let developers build front-end development on their local development.
- According to the `.github/workflows/web_build.yml` file, it uses the `JamesIves/github-pages-deploy-action@3.6.2`.
- And it should use the `v10.19.0` Node.js version at least.